### PR TITLE
read database config from env vars when on `production` environment

### DIFF
--- a/django/mdb/settings/production.py
+++ b/django/mdb/settings/production.py
@@ -1,14 +1,15 @@
 from settings.base import *
+import os
 
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': 'temp.db',
-        'USER': '',
-        'PASSWORD': '',
-        'HOST': '',
-        'PORT': '',
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': os.environ.get('MYSQL_DATABASE_NAME'),
+        'USER': os.environ.get('MYSQL_USER'),
+        'PASSWORD': os.environ.get('MYSQL_PASSWORD'),
+        'HOST': os.environ.get('MYSQL_HOST'),
+        'PORT': os.environ.get('MYSQL_PORT', '3306'),
     }
 }
 

--- a/django/requirements/base.txt
+++ b/django/requirements/base.txt
@@ -6,3 +6,4 @@ Sphinx==1.2b3
 mock==1.0.1
 djangorestframework==3.4.5
 requests==2.11.1
+gunicorn==19.6.0


### PR DESCRIPTION
added missing `gunicorn` module to requirements

the default db engine for production is `mysql`, the env vars to be set are:

  MYSQL_DATABASE_NAME
  MYSQL_USER
  MYSQL_PASSWORD
  MYSQL_HOST
  MYSQL_PORT
